### PR TITLE
Pass allowInteractive: false to hp rolls

### DIFF
--- a/scripts/autoRollUnlinkedHP.js
+++ b/scripts/autoRollUnlinkedHP.js
@@ -62,7 +62,7 @@ export function setupAutoRollUnlinkedHP() {
     if (!hpProperties[systemString]) return undefined;
     if (formula) {
       const r = new Roll(formula.replace(" ", ""));
-      await r.roll();
+      await r.roll({allowInteractive: false});
       // Make sure hp is at least 1
       const val = Math.max(r.total, 1);
       const updates = {

--- a/scripts/autoRollUnlinkedHP.js
+++ b/scripts/autoRollUnlinkedHP.js
@@ -40,7 +40,7 @@ export function setupAutoRollUnlinkedHP() {
     if (!hpProperties[systemString]) return undefined;
     if (formula) {
       const r = new Roll(formula.replace(" ", ""));
-      r.roll({ async: false });
+      r.roll({ async: false, allowInteractive: false });
       // Make sure hp is at least 1
       const val = Math.max(r.total, 1);
       foundry.utils.setProperty(data, "delta.system.attributes.hp.value", val);


### PR DESCRIPTION
This was a feature request on the Discord; under the assumption that people who have manual dice configured in FoundryVTT don't want to roll the manual health they've opted into being autorolled, we pass `allowInteractive: false` to the health roll to skip the manual input prompt.